### PR TITLE
入力形式を4パターンに増やした

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 AtCoder の入力形式を読み込んで、vis.js を用いて出力する
 
-## TODO：ここにライセンスなどを書く
+## contact
 
-This project is licensed under the MIT License, see the LICENSE.txt file for details.
+https://twitter.com/BinomialSheep
+
+## license
+
+This project is licensed under the MIT License, see the LICENSE file for details.

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
         <group class="inline-radio">
           <div><input type="radio" name="graph_format" value="edge_list" checked /><label>辺配列</label></div>
           <div><input type="radio" name="graph_format" value="transposed_edge_list" /><label>辺配列(T)</label></div>
-          <div><input type="radio" name="graph_format" value="adjancy_list" /><label>隣接リスト</label></div>
-          <div><input type="radio" name="graph_format" value="adjancy_matrix" /><label>隣接行列</label></div>
+          <div><input type="radio" name="graph_format" value="adjacency_list" /><label>隣接リスト</label></div>
+          <div><input type="radio" name="graph_format" value="adjacency_matrix" /><label>隣接行列</label></div>
         </group>
         <group class="inline-radio">
           <div><input type="radio" name="in_indexed" value="in_0_indexed" /><label>0-indexed</label></div>
@@ -44,5 +44,6 @@
       <div id="network"></div>
     </div>
     <script src="./js/script.js"></script>
+    <a href="https://github.com/BinomialSheep/sheep-visualize-graph-beta/">Github repository</a>
   </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,7 @@
-const makeGraph = (N, M, E, data, options, format) => {
+const makeGraph = (graph, format, data, option) => {
   // 頂点
-  let nodeList = new Array(N);
-  for (let i = 0; i < N; i++) {
+  let nodeList = new Array(graph.N);
+  for (let i = 0; i < graph.N; i++) {
     // 出力のindexed調整
     let label = (format.out_indexed == 'out_1_indexed' ? i + 1 : i).toString();
     nodeList[i] = { id: i, label: label };
@@ -9,14 +9,99 @@ const makeGraph = (N, M, E, data, options, format) => {
   data.nodes = new vis.DataSet(nodeList);
 
   // 辺
-  for (let i = 0; i < M; i++) {
+  for (let i = 0; i < graph.M; i++) {
     if (format.direction == 'directed') {
-      E[i].arrows = 'to';
+      graph.E[i].arrows = 'to';
     } else if (format.direction == 'opposite_directed') {
-      E[i].arrows = 'from';
+      graph.E[i].arrows = 'from';
     }
   }
-  data.edges = new vis.DataSet(E);
+  data.edges = new vis.DataSet(graph.E);
+};
+
+// 辺配列表現を正規化
+const edgeListToNormalizedGraph = (element) => {
+  let inList = element.value.split('\n');
+  let line1 = inList[0].split(' ');
+  let N = line1[0];
+  let M = inList.length - 1;
+  console.assert(line1[1] === undefined || line1[1] == M);
+  let E = new Array(M);
+  for (let i = 0; i < M; i++) {
+    let list = inList[i + 1].split(' ');
+    let A = list[0],
+      B = list[1];
+    E[i] = { from: A, to: B };
+    // 重み付きの場合
+    if (list.length >= 3) E[i].label = list[2];
+  }
+  return { N: N, M: M, E: E };
+};
+// 辺配列（転置）表現を正規化
+const transposedEdgeListToNormalizedGraph = (element) => {
+  let inList = element.value.split('\n');
+  let line1 = inList[0].split(' ');
+  let As = inList[1].split(' ');
+  let Bs = inList[2].split(' ');
+  let Cs = inList[3]?.split(' ');
+  let N = line1[0];
+  let M = As.length;
+  console.assert(Bs.length == As.length);
+  console.assert(line1[1] === undefined || line1[1] == As.length);
+  console.assert(Cs === undefined || Cs.length == As.length);
+  let E = new Array(M);
+  for (let i = 0; i < M; i++) {
+    E[i] = { from: As[i], to: Bs[i] };
+    // 重み付きの場合
+    if (Cs !== undefined) E[i].label = Cs[i];
+  }
+  return { N: N, M: M, E: E };
+};
+
+// 隣接リスト表現を正規化
+const adjacencyListToNormalizedGraph = (element) => {
+  let inList = element.value.split('\n');
+  let line1 = inList[0].split(' ');
+  let N = line1[0]; // XXX：1行目は頂点数と仮定
+  let E = new Array();
+  for (let i = 1; i < inList.length; i++) {
+    let A = i;
+    let line = inList[i].split(' ');
+    line.forEach((B) => E.push({ from: A, to: B }));
+  }
+  return { N: N, M: E.length, E: E };
+};
+// 隣接行列表現を正規化
+const adjacencyMatrixToNormalizedGraph = (element) => {
+  // XXX: 1が辺ありとみなす
+  let inList = element.value.split('\n').filter((v) => v); // NOTE：空行削除
+  let N = inList.length;
+  let E = new Array();
+  for (let i = 0; i < inList.length; i++) {
+    let line = inList[i].split(' ');
+    for (let j = 0; j < line.length; j++) {
+      if (line[j] == 1) {
+        E.push({ from: i + 1, to: j + 1 });
+      }
+    }
+  }
+  return { N: N, M: E.length, E: E };
+};
+
+const inputToNormalizedGraph = (format, element) => {
+  let graph;
+  if (format.graph_format == 'edge_list') graph = edgeListToNormalizedGraph(element);
+  if (format.graph_format == 'transposed_edge_list') graph = transposedEdgeListToNormalizedGraph(element);
+  if (format.graph_format == 'adjacency_list') graph = adjacencyListToNormalizedGraph(element);
+  if (format.graph_format == 'adjacency_matrix') graph = adjacencyMatrixToNormalizedGraph(element);
+
+  // 入力のindex調整
+  if (format.in_indexed == 'in_1_indexed')
+    graph.E.forEach((e) => {
+      e.from--, e.to--;
+    });
+
+  return graph;
 };
 
 const generateGraph = () => {
@@ -30,28 +115,13 @@ const generateGraph = () => {
   // テキストエリアの中身を取得
   let element = document.querySelector('#in_graph');
 
-  // 入力をパースしてグラフを生成
-  // TODO: 辺配列以外の入力形式にも対応
-  let inList = element.value.split('\n');
-  let line1 = inList[0].split(' ');
-  let N = line1[0],
-    M = inList.length - 1;
-  console.assert(line1[1] === undefined || line1[1] == M);
-  let E = new Array(M);
-  for (let i = 0; i < M; i++) {
-    let list = inList[i + 1].split(' ');
-    let A = list[0],
-      B = list[1];
-    if (format.in_indexed == 'in_1_indexed') A--, B--;
-    E[i] = { from: A, to: B };
-    // 重み付きの場合
-    if (list.length >= 3) E[i].label = list[2];
-  }
+  // 入力をパースしてグラフの内部表現を統一
+  let graph = inputToNormalizedGraph(format, element);
 
   // 描画用のグラフを生成
   let data = {};
   let option = {};
-  makeGraph(N, M, E, data, option, format);
+  makeGraph(graph, format, data, option);
 
   // ネットワークを描画
   let container = document.querySelector('#network');


### PR DESCRIPTION
- 可能な入力形式を3つ増やした
　- 辺配列（転置）、隣接リスト、隣接行列
　- それに伴い、パースからグラフの正規化を関数として切り出して整理
- READMEの記述を修正
- html内のスペルミス修正
- htmlにリポジトリへのリンクを追加